### PR TITLE
update binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ PVSC48 computing tutorial with focus on PV computing packages, Python, data wran
 3) Estimate module temperature from ambient
 4) Use POA irradiance and module temperature to model output power from a single-diode model.
 
+## Setup
+You can run the tutorial anytime in [Binder](https://mybinder.org) by clicking the link below:
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/main)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,57 @@
 ![tutorialpromo](images/tutorial_banner.PNG)
 
 # PVSC48-Python-Tutorial
-PVSC48 computing tutorial with focus on PV computing packages, Python, data wrangling with Pandas, and data viz
+PVSC48 computing tutorial with focus on PV computing packages, Python, data
+wrangling with Pandas, and data viz
 
 ## Tutorial Summary:
-0) Introduction to the tutorial, the lesson plan, and resources
-1) Access TMY weather data and visualize monthly irradiance data
-2) Calculate solar position, plane-of-array irradiance, and visualize average daily insolation
-3) Estimate module temperature from ambient
-4) Use POA irradiance and module temperature to model output power from a single-diode model.
+* Tutorial 0: Introduction to the tutorial, the lesson plan, and resources
+* Tutorial 1: Access TMY weather data and visualize monthly irradiance data
+* Tutorial 2: Calculate solar position, plane-of-array irradiance, and
+  visualize average daily insolation
+* Tutorial 3: Estimate module temperature from ambient
+* Tutorial 4: Use POA irradiance and module temperature to model output power
+  from a single module
+* Tutorial 5: Combine modules to form strings, calculate inverter efficiency
+  and total array output
 
-## Setup
-You can run the tutorial anytime in [Binder](https://mybinder.org) by clicking the link below:
+## Tutorial Setup
+These tutoriala are designed to run on [Jupyter](https://jupyter.org), a
+browser based interactive notebook that allows you to run the tutorial in the
+cloud without any additional setup. During the conference, June 20-25, you will
+be provided with a link and credentials to join the tutorial. After the
+conference the tutorials will remain available here on GitHub, and you can run
+the tutorial anytime in [Binder](https://mybinder.org) by clicking the
+following link:
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/main)
+
+You can also run the tutorial locally with
+[miniconda](https://docs.conda.io/en/latest/miniconda.html) by following thes
+steps:
+
+1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html).
+
+1. Clone the repository:
+
+   ```
+   git clone https://github.com/mikofski/PVSC48-Python-Tutorial.git
+   ```
+
+1. Create the environment and install the requirements. The repository includes
+   a `requirements.txt` file that contains a list the packages needed to run
+   this tutorial. To install them using conda run:
+
+   ```
+   conda create -n pvsc jupyter -c pvlib --file requirements.txt
+   conda activate pvsc
+   ```
+
+1. Start a Jupyter session:
+
+   ```
+   jupyter lab
+   ```
+
+1. Use the file explorer in Jupyter lab to browse to `PVSC48-Python-Tutorial`
+   and start the first Tutorial.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ wrangling with Pandas, and data viz
   and total array output
 
 ## Tutorial Setup
-These tutoriala are designed to run on [Jupyter](https://jupyter.org), a
+These tutorials are designed to run on [Jupyter](https://jupyter.org), a
 browser based interactive notebook that allows you to run the tutorial in the
 cloud without any additional setup. During the conference, June 20-25, you will
 be provided with a link and credentials to join the tutorial. After the

--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -108,9 +108,7 @@
    "source": [
     "# Tutorial Setup\n",
     "\n",
-    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can run them interactively using [Binder](https://mybinder.org/) by clicking the link below.\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/main?filepath=Tutorial%25200%2520-%2520Overview.ipynb)"
+    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can either run them locally by following the instructions below or online using [Binder](https://mybinder.org/) by clicking the link in the [README](../README.md)."
    ]
   },
   {
@@ -121,8 +119,9 @@
     }
    },
    "source": [
+    "You can run the tutorial locally with [miniconda](https://docs.conda.io/en/latest/miniconda.html) by following these steps:\n",
     "\n",
-    "If you choose to install the tutorial locally, follow these steps:\n",
+    "1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html).\n",
     "\n",
     "1. Clone the repository:\n",
     "\n",
@@ -130,20 +129,20 @@
     "   git clone https://github.com/mikofski/PVSC48-Python-Tutorial.git\n",
     "   ```\n",
     "\n",
-    "1. Install the environment. The repository includes an `environment.yaml` in the\n",
-    "   `.binder` subdirectory that contains a list of all the packages needed to run\n",
-    "   this tutorial. To install them using conda run:\n",
+    "1. Create the environment and install the requirements. The repository include a `requirements.txt` file that contains a list the packages needed to run this tutorial. To install them using conda run:\n",
     "\n",
     "   ```\n",
-    "   conda env create -f .binder/environment.yml\n",
-    "   conda activate pvlibenv\n",
+    "   conda create -n pvsc jupyter -c pvlib --file requirements.txt\n",
+    "   conda activate pvsc\n",
     "   ```\n",
     "\n",
     "1. Start a Jupyter session:\n",
     "\n",
     "   ```\n",
     "   jupyter lab\n",
-    "   ```\n"
+    "   ```\n",
+    "\n",
+    "1. Use the file explorer in Jupyter lab to browse to `PVSC48-Python-Tutorial` and start the first Tutorial."
    ]
   },
   {

--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -106,43 +106,9 @@
     }
    },
    "source": [
-    "# Tutorial Setup\n",
+    "# How to use this tutorial?\n",
     "\n",
-    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can either run them locally by following the instructions below or online using [Binder](https://mybinder.org/) by clicking the link in the [README](./README.md)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "subslide"
-    }
-   },
-   "source": [
-    "You can run the tutorial locally with [miniconda](https://docs.conda.io/en/latest/miniconda.html) by following these steps:\n",
-    "\n",
-    "1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html).\n",
-    "\n",
-    "1. Clone the repository:\n",
-    "\n",
-    "   ```\n",
-    "   git clone https://github.com/mikofski/PVSC48-Python-Tutorial.git\n",
-    "   ```\n",
-    "\n",
-    "1. Create the environment and install the requirements. The repository include a `requirements.txt` file that contains a list the packages needed to run this tutorial. To install them using conda run:\n",
-    "\n",
-    "   ```\n",
-    "   conda create -n pvsc jupyter -c pvlib --file requirements.txt\n",
-    "   conda activate pvsc\n",
-    "   ```\n",
-    "\n",
-    "1. Start a Jupyter session:\n",
-    "\n",
-    "   ```\n",
-    "   jupyter lab\n",
-    "   ```\n",
-    "\n",
-    "1. Use the file explorer in Jupyter lab to browse to `PVSC48-Python-Tutorial` and start the first Tutorial."
+    "This tutorial is a [Jupyter](https://jupyter.org) notebook. Jupyter is a browser based interactive tool that combines text, images, equations, and code that can be shared with others. Please see the setup section in the [README](./README.md) to learn more about how to get started."
    ]
   },
   {
@@ -153,23 +119,15 @@
     }
    },
    "source": [
-    "\n",
     "## Useful links\n",
     "\n",
-    "<ol>\n",
-    "    <li>References</li>\n",
-    "    <ul>\n",
-    "        <li> <a href=\"https://pvlib-python.readthedocs.io/en/stable/\"> PVlib Documentation </a> </li>\n",
-    "        <li> <a href=\"https://github.com/pvlib/pvlib-python\"> Github Code Repository </a> </li>\n",
-    "    </ul>\n",
-    "    <li> Ask for help:</li>\n",
-    "    <ul>\n",
-    "        <li> <a href=\"https://stackoverflow.com/questions/tagged/pvlib-python\"> Use the pvlib-python tag on StackOverflow </a> </li>\n",
-    "        <li> <a href=\"https://github.com/pyvlib/pvlib-python/issues\"> Open an Issue on the Github Repository </a> </li>\n",
-    "        <li> <a href=\"https://groups.google.com/g/pvlib-python\"> Google Group - Discussions and more! </a> </li>\n",
-    "    </ul>\n",
-    "</ol>\n",
-    "    \n"
+    "1. References\n",
+    "    * [PVlib Documentation](https://pvlib-python.readthedocs.io/en/stable/)\n",
+    "    * [Github Code Repository](https://github.com/pvlib/pvlib-python)\n",
+    "2. Ask for help:\n",
+    "    * [Use the pvlib-python tag on StackOverflow](https://stackoverflow.com/questions/tagged/pvlib-python)\n",
+    "    * [Google Group - Discussions and more!](https://groups.google.com/g/pvlib-python)\n",
+    "    * [Open an Issue on the Github Repository](https://github.com/pyvlib/pvlib-python/issues)"
    ]
   },
   {

--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "# Tutorial Setup\n",
     "\n",
-    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can either run them locally by following the instructions below or online using [Binder](https://mybinder.org/) by clicking the link in the [README](../README.md)."
+    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can either run them locally by following the instructions below or online using [Binder](https://mybinder.org/) by clicking the link in the [README](./README.md)."
    ]
   },
   {

--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -108,9 +108,9 @@
    "source": [
     "# Tutorial Setup\n",
     "\n",
-    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can run them interactively using [Binder](https://mybinder.org/) by clicking the link below:\n",
+    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can run them interactively using [Binder](https://mybinder.org/) by clicking the link below.\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/master?filepath=Tutorial%200%20-%20Overview.ipynb)\n"
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/main?filepath=Tutorial%25200%2520-%2520Overview.ipynb)"
    ]
   },
   {

--- a/Tutorial 0 - Overview.ipynb
+++ b/Tutorial 0 - Overview.ipynb
@@ -106,17 +106,11 @@
     }
    },
    "source": [
+    "# Tutorial Setup\n",
     "\n",
+    "This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and credentials to join the tutorial. After the conference the tutorials will remain available on [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can run them interactively using [Binder](https://mybinder.org/) by clicking the link below:\n",
     "\n",
-    "## Tutorial Setup\n",
-    "\n",
-    "This tutorial is designed to run on [Binder](https://mybinder.org/). This will\n",
-    "allow you to run the tutorial in the cloud without any additional setup. To get\n",
-    "started, simply click\n",
-    "\n",
-    "[here](https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master?urlpath=lab):\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master)\n",
-    "\n"
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/master?filepath=Tutorial%200%20-%20Overview.ipynb)\n"
    ]
   },
   {


### PR DESCRIPTION
I updated the link and reworded this section:

```patch
-      
-      
-      ## Tutorial Setup
-      
-      This tutorial is designed to run on [Binder](https://mybinder.org/). This will
-      allow you to run the tutorial in the cloud without any additional setup. To get
-      started, simply click
-      
-      [here](https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master?urlpath=lab):
-      [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/xarray-contrib/xarray-tutorial/master)
-      
+      This tutorial is designed to run on [Jupyter](https://jupyter.org), an online interactive notebook that allows you to run the
+      tutorial in the cloud without any additional setup. During the conference, June 20-25, you will be provided with a link and
+      credentials to join the tutorial. After the conference the tutorials will remain available on
+      [GitHub](https://github.com/mikofski/PVSC48-Python-Tutorial), and you can run them interactively using
+      [Binder](https://mybinder.org/) by clicking the link below:
+      
+      [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mikofski/PVSC48-Python-Tutorial/master?filepath=Tutorial%200%20-%20Overview.ipynb)